### PR TITLE
feat: add conversation memory to AI chatbot

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,0 +1,130 @@
+# ✨ AI Chat Memory - Feature Branch
+
+## What We Built (15 lines of code!)
+
+Your chatbot now **remembers conversations**! 🧠
+
+### Before:
+```
+You: "What's Matt's latest project?"
+Bot: "Anik.3D..."
+You: "Tell me more"
+Bot: "About what?" ❌
+```
+
+### After:
+```
+You: "What's Matt's latest project?"
+Bot: "Anik.3D..."
+You: "Tell me more"
+Bot: "Anik.3D was created for eCloudValley..." ✅
+```
+
+---
+
+## Changes Made (3 files)
+
+### 1. `src/lib/chat/types.ts` - Add history to API request
+```typescript
+export const ChatRequestSchema = z.object({
+  message: z.string().min(1).max(1000),
+  history: z.array(...)  // ← NEW: Optional conversation history
+})
+```
+
+### 2. `src/components/chat/chat-provider.tsx` - Send last 5 messages
+```typescript
+// Send last 5 messages as context
+const recentHistory = messages.slice(-5).map((msg) => ({
+  role: msg.role,
+  content: msg.content,
+}))
+
+// Include in API call
+body: JSON.stringify({
+  message: content,
+  history: recentHistory,  // ← NEW
+})
+```
+
+### 3. `src/app/api/chat/route.ts` - Use history in prompt
+```typescript
+// Build conversation context from history
+const conversationContext = history.length > 0
+  ? `\n\nPrevious conversation:\n${history.map(...)}\n`
+  : ""
+
+// Add to prompt
+const prompt = `${PORTFOLIO_CONTEXT}${conversationContext}\nUser question: ${message}`
+```
+
+---
+
+## What You Learned 🎓
+
+### 1. **Conversation Context**
+LLMs are stateless - they don't remember anything. YOU have to give them the conversation history each time.
+
+### 2. **Prompt Engineering**
+We format the history like this:
+```
+Portfolio info...
+
+Previous conversation:
+User: What's your latest project?
+Assistant: Anik.3D...
+
+User question: Tell me more
+```
+
+The AI sees the pattern and understands "more" refers to Anik.3D!
+
+### 3. **Token Management**
+We only send last 5 messages (not all 100!) to save tokens and stay under limits.
+
+---
+
+## Test It Locally
+
+```bash
+# Dev server should still be running!
+# Open http://localhost:3000
+
+# Try this conversation:
+1. "What's Matt's latest project?"
+2. "Tell me more about it"
+3. "What tech stack did he use?"
+
+# The bot remembers the context! 🎉
+```
+
+---
+
+## Next Steps
+
+**Merge to main:**
+```bash
+git add .
+git commit -m "feat: add conversation memory to AI chatbot"
+git push origin feat/ai-chat-memory
+
+# Then create PR on GitHub, review, merge!
+```
+
+**Or continue building:**
+- Add "Clear chat" button
+- Show message timestamps
+- Add typing indicators
+- Add streaming responses
+
+---
+
+## AI Concepts Used
+
+✅ **Stateless LLMs** - Models don't remember, you provide context
+✅ **Prompt Engineering** - Structure prompts for better results  
+✅ **Context Window** - Limited space, so send only recent messages
+✅ **Zero-shot Learning** - AI understands "it" without training
+
+This is how ChatGPT, Claude, and all AI chatbots work! 🚀
+

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
       )
     }
 
-    const { message } = validation.data
+    const { message, history = [] } = validation.data
 
     if (!process.env.GEMINI_API_KEY) {
       return NextResponse.json(
@@ -36,7 +36,13 @@ export async function POST(request: Request) {
       },
     })
 
-    const prompt = `${PORTFOLIO_CONTEXT}\n\nUser question: ${message}\n\nPlease provide a helpful response about Matt Enarle based on the context above.`
+    // Build conversation context from history
+    const conversationContext =
+      history.length > 0
+        ? `\n\nPrevious conversation:\n${history.map((msg) => `${msg.role === "user" ? "User" : "Assistant"}: ${msg.content}`).join("\n")}\n`
+        : ""
+
+    const prompt = `${PORTFOLIO_CONTEXT}${conversationContext}\nUser question: ${message}\n\nPlease provide a helpful response about Matt Enarle based on the context above.`
 
     const result = await model.generateContent(prompt)
     const response = await result.response

--- a/src/components/chat/chat-provider.tsx
+++ b/src/components/chat/chat-provider.tsx
@@ -22,12 +22,21 @@ export function ChatProvider() {
     setIsLoading(true)
 
     try {
+      // Send last 5 messages as context for the AI
+      const recentHistory = messages.slice(-5).map((msg) => ({
+        role: msg.role,
+        content: msg.content,
+      }))
+
       const response = await fetch("/api/chat", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ message: content }),
+        body: JSON.stringify({
+          message: content,
+          history: recentHistory,
+        }),
       })
 
       if (!response.ok) {

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -9,6 +9,14 @@ export const MessageSchema = z.object({
 
 export const ChatRequestSchema = z.object({
   message: z.string().min(1).max(1000),
+  history: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant"]),
+        content: z.string(),
+      })
+    )
+    .optional(),
 })
 
 export const ChatResponseSchema = z.object({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable conversation memory by sending the last 5 messages as history and incorporating them into the backend prompt.
> 
> - **Backend**:
>   - `src/lib/chat/types.ts`: Extend `ChatRequestSchema` with optional `history` array (`{ role, content }`).
>   - `src/app/api/chat/route.ts`: Accept `history`, build `conversationContext`, and append it to the Gemini prompt.
> - **Frontend**:
>   - `src/components/chat/chat-provider.tsx`: Send last 5 messages as `history` in API requests.
> - **Docs**:
>   - Add `FEATURE_PLAN.md` describing the feature and usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0e923e5b70428a0943f6859bccf970fda0207f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->